### PR TITLE
CASMHMS-5608 Update internal HMS documentation for Helm CT tests

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-(C) Copyright [2021] Hewlett Packard Enterprise Development LP
+(C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/README.md
+++ b/README.md
@@ -251,12 +251,6 @@ TODO: Explain what these tests test and why
 TODO: Give an example
 ```
 
-### RTS CT Testing
-
-This repository builds and publishes hms-rts-ct-test RPMs along with the service itself containing tests that verify RTS on the
-NCNs of live Shasta systems. The tests require the hms-ct-test-base RPM to also be installed on the NCNs in order to execute.
-The version of the test RPM installed on the NCNs should always match the version of RTS deployed on the system.
-
 ## Deployment
 
 TODO: Add additional notes about how to deploy this on a live system


### PR DESCRIPTION
### Summary and Scope

- Remove CT testing section of README since we're now using Helm-based tests instead of RPMs and the former RTS CT tests required Kubernetes which won't run inside the service mesh.
- Assorted README cleanup.

### Issues and Related PRs

* Partially resolves CASMHMS-5608.

### Testing

- Rendered README updates and viewed them to verify that they look as expected.
- No testing performed due to documentation change only.

Was a fresh Install tested? N/A
Was an Upgrade tested? N/A
Was a Downgrade tested? N/A

### Risks and Mitigations

None, README change only.