### PR TITLE
Added env var for TLS handshake issue to Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -76,6 +76,8 @@ ENV JAWS_POLLING_ENABLED=true
 ENV JAWS_POLLING_INTERVAL=10
 ENV JAWS_POLLING_WORKERS=30
 
+ENV GODEBUG=tlsrsakex=1
+
 RUN set -ex \
     && apk -U upgrade \
     && apk add redis curl \

--- a/Dockerfile.pprof
+++ b/Dockerfile.pprof
@@ -77,6 +77,8 @@ ENV JAWS_POLLING_ENABLED=true
 ENV JAWS_POLLING_INTERVAL=10
 ENV JAWS_POLLING_WORKERS=30
 
+ENV GODEBUG=tlsrsakex=1
+
 RUN set -ex \
     && apk -U upgrade \
     && apk add redis curl \

--- a/Dockerfile.testing
+++ b/Dockerfile.testing
@@ -62,6 +62,8 @@ ENV JAWS_POLLING_ENABLED=true
 ENV JAWS_POLLING_INTERVAL=10
 ENV JAWS_POLLING_WORKERS=30
 
+ENV GODEBUG=tlsrsakex=1
+
 # Copy support files into the image.
 COPY scripts/wait-for.sh /
 COPY docker-entrypoint.sh /


### PR DESCRIPTION
## Summary and Scope

Adds Environment Variable to Docker Files which uses old TLS Handshaking protocols which have been disabled by default
by golang

## Issues and Related PRs

* CASMHMS-6553

## Testing

Tested locally

Test description:

Ran test case with and with out variable set - test fails with out variable set.

## Risks and Mitigations

No Risk - just ads an environment variable to Docker files

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
